### PR TITLE
feat(Gemfile): bump version of rexml 3.6.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,22 +37,16 @@ GEM
     faker (2.21.0)
       i18n (>= 1.8.11, < 2)
     fakeweb (1.3.0)
-    httparty (0.20.0)
-      mime-types (~> 3.0)
-      multi_xml (>= 0.5.2)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
-    mime-types (3.4.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
     minitest (5.15.0)
-    multi_xml (0.6.0)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
     rake (13.0.6)
-    rexml (3.2.5)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -66,6 +60,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
+    strscan (3.1.0)
     thor (1.2.1)
     thread_safe (0.3.6)
     tzinfo (1.2.9)
@@ -83,7 +78,6 @@ DEPENDENCIES
   factory_bot
   faker
   fakeweb (~> 1.3.0)
-  httparty
   pry
   rake
   rexml

--- a/spec/resources/subscription_spec.rb
+++ b/spec/resources/subscription_spec.rb
@@ -70,7 +70,7 @@ describe Chargify::Subscription, :fake_resource do
 
   it 'creates a one-time charge' do
     id = generate(:subscription_id)
-    subscription = build(:subscription, id:)
+    subscription = build(:subscription, id: id)
     allow(subscription).to receive(:persisted?).and_return(true)
     expected_response = { charge: { amount_in_cents: 1000, memo: 'one-time charge', success: true } }.to_xml
     FakeWeb.register_uri(:post, "#{test_domain}/subscriptions/#{id}/charges.xml", status: 201,
@@ -105,7 +105,7 @@ describe Chargify::Subscription, :fake_resource do
 
   it 'migrates the subscription' do
     id = generate(:subscription_id)
-    subscription = build(:subscription, id:)
+    subscription = build(:subscription, id: id)
     allow(subscription).to receive(:persisted?).and_return(true)
     expected_response = [subscription.attributes].to_xml(root: 'subscription')
     FakeWeb.register_uri(:post,
@@ -171,7 +171,7 @@ describe Chargify::Subscription, :fake_resource do
     let(:statement_id) { 1234 }
     let(:subscription_id) { 4242 }
     let(:statement) do
-      { id: statement_id, subscription_id: }
+      { id: statement_id, subscription_id: subscription_id }
     end
 
     before do
@@ -225,7 +225,7 @@ describe Chargify::Subscription, :fake_resource do
     let(:invoice_id) { 1234 }
     let(:subscription_id) { 4242 }
     let(:invoice) do
-      { id: invoice_id, subscription_id: }
+      { id: invoice_id, subscription_id: subscription_id }
     end
 
     before do


### PR DESCRIPTION
bump version of `rexml` gem to 3.6.8 to fix security issues

Releases 3.6.5 to 3.6.8
https://github.com/ruby/rexml/releases

Also, fixes some failing specs on subscription_spec.rb due to syntax issues