### PR TITLE
feat(dependencies): bump rexml to 3.3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,8 +45,8 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     rake (13.0.6)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.2)
+      strscan
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -85,4 +85,4 @@ DEPENDENCIES
   vcr (~> 2.9.3)
 
 BUNDLED WITH
-   2.3.13
+   2.5.14


### PR DESCRIPTION
bump `rexml` gem from 3.2.8 to 3.3.2
https://github.com/ruby/rexml/releases/tag/v3.3.2